### PR TITLE
Added ARM64 as package option in cmake

### DIFF
--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -82,7 +82,11 @@ IF(UNIX AND NOT APPLE)
 
 
   IF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-    SET (ARCH "armhf")
+    IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
+      SET (ARCH "arm64")
+    ELSE ()
+      SET (ARCH "armhf")
+    ENDIF ()
     # don't bother with rpm on armhf
     SET(CPACK_GENERATOR "DEB;RPM;TBZ2")
   ELSE ()


### PR DESCRIPTION
Small change makes creating a package for arm64 possible.
	modified:   cmake/PluginPackage.cmake